### PR TITLE
Version 0.0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eswiss",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "private": false,
   "peerDependencies": {
     "react": "^16.13.1",

--- a/src/__snapshots__/storybook.test.ts.snap
+++ b/src/__snapshots__/storybook.test.ts.snap
@@ -122,6 +122,13 @@ exports[`Storyshots Modal Body Fullscreen 1`] = `
   <section
     className="modal modal-full"
   >
+    <section
+      className="modal-content"
+    >
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam congue enim ac nibh dictum, eu hendrerit enim malesuada. Vivamus et magna dignissim ipsum viverra pretium quis interdum dui. Proin eget rhoncus arcu, ut feugiat est. Integer eget nulla sed orci gravida aliquet. Sed a luctus metus, ac porta ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque non vestibulum quam. Vivamus porta vulputate ultrices. Ut et congue purus. Sed id tortor et sem cursus aliquet sed eget nibh. Sed scelerisque quam eleifend dolor pellentesque, eget ultricies justo aliquam. Praesent eu tortor sed diam dignissim accumsan. Cras sit amet ex mi.
+      </p>
+    </section>
     <button
       aria-label="Close Modal"
       className="modal-close"
@@ -130,13 +137,6 @@ exports[`Storyshots Modal Body Fullscreen 1`] = `
     >
       X
     </button>
-    <section
-      className="modal-content"
-    >
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam congue enim ac nibh dictum, eu hendrerit enim malesuada. Vivamus et magna dignissim ipsum viverra pretium quis interdum dui. Proin eget rhoncus arcu, ut feugiat est. Integer eget nulla sed orci gravida aliquet. Sed a luctus metus, ac porta ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque non vestibulum quam. Vivamus porta vulputate ultrices. Ut et congue purus. Sed id tortor et sem cursus aliquet sed eget nibh. Sed scelerisque quam eleifend dolor pellentesque, eget ultricies justo aliquam. Praesent eu tortor sed diam dignissim accumsan. Cras sit amet ex mi.
-      </p>
-    </section>
   </section>
 </div>
 `;
@@ -150,6 +150,13 @@ exports[`Storyshots Modal Body Text 1`] = `
   <section
     className="modal"
   >
+    <section
+      className="modal-content"
+    >
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam congue enim ac nibh dictum, eu hendrerit enim malesuada. Vivamus et magna dignissim ipsum viverra pretium quis interdum dui. Proin eget rhoncus arcu, ut feugiat est. Integer eget nulla sed orci gravida aliquet. Sed a luctus metus, ac porta ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque non vestibulum quam. Vivamus porta vulputate ultrices. Ut et congue purus. Sed id tortor et sem cursus aliquet sed eget nibh. Sed scelerisque quam eleifend dolor pellentesque, eget ultricies justo aliquam. Praesent eu tortor sed diam dignissim accumsan. Cras sit amet ex mi.
+      </p>
+    </section>
     <button
       aria-label="Close Modal"
       className="modal-close"
@@ -158,13 +165,6 @@ exports[`Storyshots Modal Body Text 1`] = `
     >
       X
     </button>
-    <section
-      className="modal-content"
-    >
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam congue enim ac nibh dictum, eu hendrerit enim malesuada. Vivamus et magna dignissim ipsum viverra pretium quis interdum dui. Proin eget rhoncus arcu, ut feugiat est. Integer eget nulla sed orci gravida aliquet. Sed a luctus metus, ac porta ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque non vestibulum quam. Vivamus porta vulputate ultrices. Ut et congue purus. Sed id tortor et sem cursus aliquet sed eget nibh. Sed scelerisque quam eleifend dolor pellentesque, eget ultricies justo aliquam. Praesent eu tortor sed diam dignissim accumsan. Cras sit amet ex mi.
-      </p>
-    </section>
   </section>
 </div>
 `;
@@ -215,14 +215,6 @@ Array [
         }
       }
     >
-      <button
-        aria-label="Close Modal"
-        className="modal-close"
-        onClick={[Function]}
-        type="button"
-      >
-        X
-      </button>
       <section
         className="modal-content"
       >
@@ -235,6 +227,14 @@ Array [
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam congue enim ac nibh dictum, eu hendrerit enim malesuada. Vivamus et magna dignissim ipsum viverra pretium quis interdum dui. Proin eget rhoncus arcu, ut feugiat est. Integer eget nulla sed orci gravida aliquet. Sed a luctus metus, ac porta ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque non vestibulum quam. Vivamus porta vulputate ultrices. Ut et congue purus. Sed id tortor et sem cursus aliquet sed eget nibh. Sed scelerisque quam eleifend dolor pellentesque, eget ultricies justo aliquam. Praesent eu tortor sed diam dignissim accumsan. Cras sit amet ex mi.
         </p>
       </section>
+      <button
+        aria-label="Close Modal"
+        className="modal-close"
+        onClick={[Function]}
+        type="button"
+      >
+        X
+      </button>
     </section>
   </div>,
 ]
@@ -249,14 +249,6 @@ exports[`Storyshots Modal Heading 1`] = `
   <section
     className="modal"
   >
-    <button
-      aria-label="Close Modal"
-      className="modal-close"
-      onClick={[Function]}
-      type="button"
-    >
-      X
-    </button>
     <section
       className="modal-content"
     >
@@ -266,6 +258,14 @@ exports[`Storyshots Modal Heading 1`] = `
         Lorem Ipsum
       </h1>
     </section>
+    <button
+      aria-label="Close Modal"
+      className="modal-close"
+      onClick={[Function]}
+      type="button"
+    >
+      X
+    </button>
   </section>
 </div>
 `;
@@ -279,14 +279,6 @@ exports[`Storyshots Modal Heading And Text 1`] = `
   <section
     className="modal"
   >
-    <button
-      aria-label="Close Modal"
-      className="modal-close"
-      onClick={[Function]}
-      type="button"
-    >
-      X
-    </button>
     <section
       className="modal-content"
     >
@@ -299,6 +291,14 @@ exports[`Storyshots Modal Heading And Text 1`] = `
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam congue enim ac nibh dictum, eu hendrerit enim malesuada. Vivamus et magna dignissim ipsum viverra pretium quis interdum dui. Proin eget rhoncus arcu, ut feugiat est. Integer eget nulla sed orci gravida aliquet. Sed a luctus metus, ac porta ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque non vestibulum quam. Vivamus porta vulputate ultrices. Ut et congue purus. Sed id tortor et sem cursus aliquet sed eget nibh. Sed scelerisque quam eleifend dolor pellentesque, eget ultricies justo aliquam. Praesent eu tortor sed diam dignissim accumsan. Cras sit amet ex mi.
       </p>
     </section>
+    <button
+      aria-label="Close Modal"
+      className="modal-close"
+      onClick={[Function]}
+      type="button"
+    >
+      X
+    </button>
   </section>
 </div>
 `;
@@ -312,14 +312,6 @@ exports[`Storyshots Modal Heading And Text Fullscreen 1`] = `
   <section
     className="modal modal-full"
   >
-    <button
-      aria-label="Close Modal"
-      className="modal-close"
-      onClick={[Function]}
-      type="button"
-    >
-      X
-    </button>
     <section
       className="modal-content"
     >
@@ -332,6 +324,14 @@ exports[`Storyshots Modal Heading And Text Fullscreen 1`] = `
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam congue enim ac nibh dictum, eu hendrerit enim malesuada. Vivamus et magna dignissim ipsum viverra pretium quis interdum dui. Proin eget rhoncus arcu, ut feugiat est. Integer eget nulla sed orci gravida aliquet. Sed a luctus metus, ac porta ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque non vestibulum quam. Vivamus porta vulputate ultrices. Ut et congue purus. Sed id tortor et sem cursus aliquet sed eget nibh. Sed scelerisque quam eleifend dolor pellentesque, eget ultricies justo aliquam. Praesent eu tortor sed diam dignissim accumsan. Cras sit amet ex mi.
       </p>
     </section>
+    <button
+      aria-label="Close Modal"
+      className="modal-close"
+      onClick={[Function]}
+      type="button"
+    >
+      X
+    </button>
   </section>
 </div>
 `;
@@ -350,6 +350,13 @@ exports[`Storyshots Modal Modal With Width 1`] = `
       }
     }
   >
+    <section
+      className="modal-content"
+    >
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam congue enim ac nibh dictum, eu hendrerit enim malesuada. Vivamus et magna dignissim ipsum viverra pretium quis interdum dui. Proin eget rhoncus arcu, ut feugiat est. Integer eget nulla sed orci gravida aliquet. Sed a luctus metus, ac porta ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque non vestibulum quam. Vivamus porta vulputate ultrices. Ut et congue purus. Sed id tortor et sem cursus aliquet sed eget nibh. Sed scelerisque quam eleifend dolor pellentesque, eget ultricies justo aliquam. Praesent eu tortor sed diam dignissim accumsan. Cras sit amet ex mi.
+      </p>
+    </section>
     <button
       aria-label="Close Modal"
       className="modal-close"
@@ -358,13 +365,6 @@ exports[`Storyshots Modal Modal With Width 1`] = `
     >
       X
     </button>
-    <section
-      className="modal-content"
-    >
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam congue enim ac nibh dictum, eu hendrerit enim malesuada. Vivamus et magna dignissim ipsum viverra pretium quis interdum dui. Proin eget rhoncus arcu, ut feugiat est. Integer eget nulla sed orci gravida aliquet. Sed a luctus metus, ac porta ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque non vestibulum quam. Vivamus porta vulputate ultrices. Ut et congue purus. Sed id tortor et sem cursus aliquet sed eget nibh. Sed scelerisque quam eleifend dolor pellentesque, eget ultricies justo aliquam. Praesent eu tortor sed diam dignissim accumsan. Cras sit amet ex mi.
-      </p>
-    </section>
   </section>
 </div>
 `;

--- a/src/components/Modal/_index.scss
+++ b/src/components/Modal/_index.scss
@@ -1,4 +1,4 @@
-body.modal-open {
+body.disable-bg-scroll {
   overflow: hidden;
 }
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -174,12 +174,12 @@ const Modal = ({
     if (focusEleOnClose) focusEleOnClose.focus()
   }
 
-  const modalEle = useRef<HTMLElement>(null)
+  const overlayEle = useRef<HTMLDivElement>(null)
   const [tabNavEnd, setTabNavEnd] = useState<HTMLElement>()
 
   // Setup keyboard tab trap, tabNavStart & tabNavEnd
   useEffect(() => {
-    if (modalEle && modalEle.current) {
+    if (overlayEle && overlayEle.current) {
       /**
        * Setup keyboard tab trap
        * @param {KeyboardEvent} e Keyboard event object
@@ -206,25 +206,22 @@ const Modal = ({
         }
       }
 
-      const currModalEle = modalEle.current
-      const tabNav = currModalEle.querySelectorAll(
+      const currOverlayEle = overlayEle.current
+      const tabNav = currOverlayEle.querySelectorAll(
         '[contenteditable], [tabindex="0"], a[href], area[href], button:not([disabled]), embed, iframe, input:not([disabled]), object, select:not([disabled]), textarea:not([disabled])'
       )
 
       // Set tabNavStart & tabNavEnd
       if (tabNav.length > 0) {
-        const tabNavStart = tabNav[0] as HTMLElement
-        setTabNavStart(tabNavStart)
+        setTabNavStart(tabNav[0] as HTMLElement)
         setTabNavEnd(tabNav[tabNav.length - 1] as HTMLElement)
       }
 
       // Apply keyboard tab trap on modal
-      currModalEle.addEventListener('keydown', trapTab)
-      return () => currModalEle.removeEventListener('keydown', trapTab)
+      currOverlayEle.addEventListener('keydown', trapTab)
+      return () => currOverlayEle.removeEventListener('keydown', trapTab)
     }
   }, [tabNavStart, tabNavEnd]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const overlayEle = useRef<HTMLDivElement>(null)
 
   // Handle overlay click event listener
   useEffect(() => {
@@ -254,6 +251,7 @@ const Modal = ({
   }, [closeOnOverlayClick]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-center modal if conditions are met
+  const modalEle = useRef<HTMLElement>(null)
   const viewportWidth = useViewportWidth(__IS_SERVER__)
   const viewportHeight = useViewportHeight(__IS_SERVER__)
   useEffect(() => {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -7,7 +7,21 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { useViewportHeight, useViewportWidth } from '../../util'
+import {
+  DISABLE_BG_SCROLL_CLASS,
+  setBodyScroll,
+  useViewportHeight,
+  useViewportWidth,
+} from '../../util'
+
+// CSS class that controls if modal is open
+const MODAL_OPEN_CLASS = 'modal-open'
+// CSS class that controls if modal is full
+const MODAL_FULL_CLASS = 'modal-full'
+// CSS class that controls if modal is centered horizontally
+const MODAL_CENTERH_CLASS = 'modal-centerh'
+// CSS class that controls if modal is centered vertically
+const MODAL_CENTERV_CLASS = 'modal-centerv'
 
 export interface Props {
   __IS_SERVER__?: boolean
@@ -98,31 +112,17 @@ const Modal = ({
   useAriaHidden,
   useAriaModal,
 }: Props) => {
-  const MODAL_OPEN_CLASS = 'modal-open' // CSS class that controls if modal is open visually
-
   // Use aria-modal in default conditions
   if (useAriaModal === undefined && useAriaHidden === undefined) {
     useAriaModal = true
   }
 
-  /**
-   * Control existance of modal-open CSS class on body element
-   * @param {boolean} open modal-open CSS class exists on body element if true
-   */
-  const setBodyModalState = (open: boolean) => {
-    if (open) {
-      document.body.classList.add(MODAL_OPEN_CLASS)
-    } else {
-      document.body.classList.remove(MODAL_OPEN_CLASS)
-    }
-  }
-
   const [tabNavStart, setTabNavStart] = useState<HTMLElement>()
 
-  // Apply modal-open CSS class to body element if isOpen
   useEffect(() => {
     if (isOpen) {
-      if (!allowBgScroll) setBodyModalState(true)
+      // Disable background scrolling while modal is open
+      if (!allowBgScroll) setBodyScroll(false)
 
       // Hide background content from a11y API
       if (hideEleWithAria) {
@@ -142,19 +142,19 @@ const Modal = ({
     }
 
     // Remove modal-open CSS class on body on unmount
-    return () => document.body.classList.remove(MODAL_OPEN_CLASS)
+    return () => document.body.classList.remove(DISABLE_BG_SCROLL_CLASS)
   }, [allowBgScroll, hideEleWithAria, isOpen, onOpen, tabNavStart])
 
   // Remove modal-open CSS class from body element if allowBgScroll is changed to false
   useEffect(() => {
-    if (!allowBgScroll) document.body.classList.remove(MODAL_OPEN_CLASS)
+    if (!allowBgScroll) document.body.classList.remove(DISABLE_BG_SCROLL_CLASS)
   }, [allowBgScroll])
 
   /**
    * Function called when onClose event is triggered
    */
   const closeModal = () => {
-    setBodyModalState(false)
+    setBodyScroll(true)
 
     // Expose background content for a11y API
     if (hideEleWithAria) {
@@ -260,17 +260,17 @@ const Modal = ({
     if (modalEle && modalEle.current) {
       if (autoCenterH && typeof viewportWidth === 'number') {
         if (modalEle.current.offsetWidth < viewportWidth) {
-          modalEle.current.classList.add('modal-centerh')
+          modalEle.current.classList.add(MODAL_CENTERH_CLASS)
         } else {
-          modalEle.current.classList.remove('modal-centerh')
+          modalEle.current.classList.remove(MODAL_CENTERH_CLASS)
         }
       }
 
       if (autoCenterV && typeof viewportHeight === 'number') {
         if (modalEle.current.offsetHeight < viewportHeight) {
-          modalEle.current.classList.add('modal-centerv')
+          modalEle.current.classList.add(MODAL_CENTERV_CLASS)
         } else {
-          modalEle.current.classList.remove('modal-centerv')
+          modalEle.current.classList.remove(MODAL_CENTERV_CLASS)
         }
       }
     }
@@ -290,7 +290,7 @@ const Modal = ({
     if (isOpen) overlayClassNames.push(MODAL_OPEN_CLASS)
   }
 
-  if (isFull) modalClassNames.push('modal-full')
+  if (isFull) modalClassNames.push(MODAL_FULL_CLASS)
 
   if (modalClassName) {
     modalClassNames.push(modalClassName)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,19 @@
 import { useEffect, useState } from 'react'
 
+export const DISABLE_BG_SCROLL_CLASS = 'disable-bg-scroll'
+
+/**
+ * Control if scrolling is enabled in background when modal is opened
+ * @param {boolean} allowScrolling Allow scrolling if true, false otherwise
+ */
+export const setBodyScroll = (allowScrolling: boolean) => {
+  if (allowScrolling) {
+    document.body.classList.remove(DISABLE_BG_SCROLL_CLASS)
+  } else {
+    document.body.classList.add(DISABLE_BG_SCROLL_CLASS)
+  }
+}
+
 /**
  * Custom hook that runs a function when component mounts
  * @param {() => void} cb Callback function to run on component mount


### PR DESCRIPTION
### Utility
- Split control of body scroll functionality into its own `util` function

### Modal
- Add `disableTabTrap` that disables adding of tab trap event listener
- Set default `onOpen` function that focuses on first focusable element
- Apply tab trap event listener on overlay instead of window
- Fix bug where body scroll state is not set correctly when `allowBgScroll` is changed
- Move `modal-close` button to end of modal window markup mitigate background focus bug